### PR TITLE
[codex] Promote README doctests to mbt check

### DIFF
--- a/data_structures/splay/README.mbt.md
+++ b/data_structures/splay/README.mbt.md
@@ -11,13 +11,13 @@ workloads.
 - Automatically keeps the most recently accessed key at the root.
 
 ## Quick Start
-```moonbit nocheck
+```mbt check
 ///|
 test "README basic usage" {
   let tree : SplayTree[Int, String] = SplayTree::new()
   tree.insert(42, "answer")
   tree.insert(7, "lucky")
-  assert_eq(tree.get(7), Some("lucky"))
+  @debug.assert_eq(tree.get(7), Some("lucky"))
   tree.insert(15, "middle")
   assert_eq(tree.remove(42), true)
   assert_eq(tree.contains(42), false)

--- a/data_structures/treap/README.mbt.md
+++ b/data_structures/treap/README.mbt.md
@@ -10,7 +10,7 @@ like an ordered map keyed by `Compare` values.
 - Deterministic pseudo-random priorities keep the tree reproducible in tests.
 
 ## Quick Start
-```moonbit nocheck
+```mbt check
 ///|
 test "README treap usage" {
   let treap : Treap[Int, String] = Treap::new()
@@ -18,10 +18,10 @@ test "README treap usage" {
   treap.insert(3, "three")
   treap.insert(5, "five")
   assert_eq(treap.len(), 3)
-  assert_eq(treap.get(5), Some("five"))
+  @debug.assert_eq(treap.get(5), Some("five"))
   assert_eq(treap.contains(7), false)
   treap.insert(5, "FIVE")
-  assert_eq(treap.get(5), Some("FIVE"))
+  @debug.assert_eq(treap.get(5), Some("FIVE"))
   assert_eq(treap.remove(3), true)
   assert_eq(treap.contains(3), false)
   treap.clear()


### PR DESCRIPTION
## Summary

- Promote README.mbt.md doctest fences from `moonbit nocheck` to `mbt check`.
- Adjust README assertions to avoid current deprecation warnings under `--deny-warn`.

## Validation

- `moon check --deny-warn`