### PR TITLE
Fix MoonBit nightly warnings

### DIFF
--- a/algorithm/pkg.generated.mbti
+++ b/algorithm/pkg.generated.mbti
@@ -43,8 +43,8 @@ pub(all) struct Point {
   x : Int
   y : Int
 } derive(@debug.Debug)
+pub fn Point::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 
 // Traits
-

--- a/algorithm/trait_extensions.mbt
+++ b/algorithm/trait_extensions.mbt
@@ -1,0 +1,2 @@
+///|
+pub extend Point with Debug::{to_repr}

--- a/data_structures/avl/pkg.generated.mbti
+++ b/data_structures/avl/pkg.generated.mbti
@@ -35,4 +35,3 @@ pub(all) struct AVLTree {
 // Type aliases
 
 // Traits
-

--- a/data_structures/binary_indexed/pkg.generated.mbti
+++ b/data_structures/binary_indexed/pkg.generated.mbti
@@ -14,4 +14,3 @@ pub fn Tree::update(Self[Int], Int, Int, Int) -> Unit
 // Type aliases
 
 // Traits
-

--- a/data_structures/cartesian_tree/pkg.generated.mbti
+++ b/data_structures/cartesian_tree/pkg.generated.mbti
@@ -26,4 +26,3 @@ pub fn[T] CartesianTree::value_at(Self[T], Int) -> T?
 // Type aliases
 
 // Traits
-

--- a/data_structures/chtholly_tree/chtholly_tree.mbt
+++ b/data_structures/chtholly_tree/chtholly_tree.mbt
@@ -270,6 +270,6 @@ fn ChthollyTree::split(self : ChthollyTree, pos : Int) -> Int {
 }
 
 ///|
-pub impl Default for ChthollyTree with default() {
+pub impl Default for ChthollyTree with fn default() {
   ChthollyTree::new(0, 0)
 }

--- a/data_structures/chtholly_tree/pkg.generated.mbti
+++ b/data_structures/chtholly_tree/pkg.generated.mbti
@@ -16,12 +16,14 @@ pub struct ChthollyTree {
 } derive(@debug.Debug)
 pub fn ChthollyTree::add(Self, Int, Int, Int) -> Result[Unit, ChthollyTreeError]
 pub fn ChthollyTree::assign(Self, Int, Int, Int) -> Result[Unit, ChthollyTreeError]
+pub fn ChthollyTree::default() -> Self
 pub fn ChthollyTree::from_array(Array[Int]) -> Self
 pub fn ChthollyTree::is_empty(Self) -> Bool
 pub fn ChthollyTree::len(Self) -> Int
 pub fn ChthollyTree::new(Int, Int) -> Self
 pub fn ChthollyTree::query_sum(Self, Int, Int) -> Result[Int, ChthollyTreeError]
 pub fn ChthollyTree::size(Self) -> Int
+pub fn ChthollyTree::to_repr(Self) -> @debug.Repr
 pub fn ChthollyTree::value_at(Self, Int) -> Result[Int, ChthollyTreeError]
 pub impl Default for ChthollyTree
 
@@ -29,10 +31,15 @@ pub enum ChthollyTreeError {
   IndexOutOfBounds
   InvalidRange
 } derive(Eq, @debug.Debug)
+pub fn ChthollyTreeError::equal(Self, Self) -> Bool
+pub fn ChthollyTreeError::not_equal(Self, Self) -> Bool
+pub fn ChthollyTreeError::to_repr(Self) -> @debug.Repr
 
 type Interval derive(Eq, @debug.Debug)
+pub fn Interval::equal(Self, Self) -> Bool
+pub fn Interval::not_equal(Self, Self) -> Bool
+pub fn Interval::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 
 // Traits
-

--- a/data_structures/chtholly_tree/trait_extensions.mbt
+++ b/data_structures/chtholly_tree/trait_extensions.mbt
@@ -1,0 +1,17 @@
+///|
+pub extend ChthollyTreeError with Debug::{to_repr}
+
+///|
+pub extend ChthollyTreeError with Eq::{not_equal, equal}
+
+///|
+pub extend Interval with Debug::{to_repr}
+
+///|
+pub extend Interval with Eq::{not_equal, equal}
+
+///|
+pub extend ChthollyTree with Debug::{to_repr}
+
+///|
+pub extend ChthollyTree with Default::{default}

--- a/data_structures/dsu/pkg.generated.mbti
+++ b/data_structures/dsu/pkg.generated.mbti
@@ -16,4 +16,3 @@ pub fn DSU::size(Self, Int) -> Int
 // Type aliases
 
 // Traits
-

--- a/data_structures/euler_tour_tree/pkg.generated.mbti
+++ b/data_structures/euler_tour_tree/pkg.generated.mbti
@@ -26,4 +26,3 @@ type Node
 // Type aliases
 
 // Traits
-

--- a/data_structures/heap/pkg.generated.mbti
+++ b/data_structures/heap/pkg.generated.mbti
@@ -22,4 +22,3 @@ pub fn[T] Heap::pop(Self[T]) -> T?
 // Type aliases
 
 // Traits
-

--- a/data_structures/hld/pkg.generated.mbti
+++ b/data_structures/hld/pkg.generated.mbti
@@ -22,4 +22,3 @@ pub fn HeavyLightDecomposition::subtree_range(Self, Int) -> (Int, Int)
 // Type aliases
 
 // Traits
-

--- a/data_structures/immutable_segment_tree/immutable_segment_tree.mbt
+++ b/data_structures/immutable_segment_tree/immutable_segment_tree.mbt
@@ -12,7 +12,7 @@ pub enum PersistentSegmentTreeError {
 } derive(Debug, Eq)
 
 ///|
-pub impl Show for PersistentSegmentTreeError with output(self, logger) {
+pub impl Show for PersistentSegmentTreeError with fn output(self, logger) {
   match self {
     IndexOutOfBounds => logger.write_string("IndexOutOfBounds")
     InvalidRange => logger.write_string("InvalidRange")
@@ -27,7 +27,7 @@ pub struct PersistentSegmentTree[T] {
 } derive(Debug)
 
 ///|
-pub impl[T] Show for PersistentSegmentTree[T] with output(_self, logger) {
+pub impl[T] Show for PersistentSegmentTree[T] with fn output(_self, logger) {
   logger.write_string("PersistentSegmentTree")
 }
 

--- a/data_structures/immutable_segment_tree/pkg.generated.mbti
+++ b/data_structures/immutable_segment_tree/pkg.generated.mbti
@@ -11,6 +11,7 @@ import {
 
 // Types and methods
 type Node[T] derive(@debug.Debug)
+pub fn[T : @debug.Debug] Node::to_repr(Self[T]) -> @debug.Repr
 
 pub struct PersistentSegmentTree[T] {
   size : Int
@@ -18,7 +19,10 @@ pub struct PersistentSegmentTree[T] {
   merge : (T, T) -> T
 } derive(@debug.Debug)
 pub fn[T] PersistentSegmentTree::from_array(Array[T], (T, T) -> T) -> Self[T]
+pub fn[T] PersistentSegmentTree::output(Self[T], &Logger) -> Unit
 pub fn[T] PersistentSegmentTree::query(Self[T], Int, Int) -> Result[T?, PersistentSegmentTreeError]
+pub fn[T : @debug.Debug] PersistentSegmentTree::to_repr(Self[T]) -> @debug.Repr
+pub fn[T] PersistentSegmentTree::to_string(Self[T]) -> String
 pub fn[T] PersistentSegmentTree::update(Self[T], Int, T) -> Result[Self[T], PersistentSegmentTreeError]
 pub impl[T] Show for PersistentSegmentTree[T]
 
@@ -26,9 +30,13 @@ pub enum PersistentSegmentTreeError {
   IndexOutOfBounds
   InvalidRange
 } derive(Eq, @debug.Debug)
+pub fn PersistentSegmentTreeError::equal(Self, Self) -> Bool
+pub fn PersistentSegmentTreeError::not_equal(Self, Self) -> Bool
+pub fn PersistentSegmentTreeError::output(Self, &Logger) -> Unit
+pub fn PersistentSegmentTreeError::to_repr(Self) -> @debug.Repr
+pub fn PersistentSegmentTreeError::to_string(Self) -> String
 pub impl Show for PersistentSegmentTreeError
 
 // Type aliases
 
 // Traits
-

--- a/data_structures/immutable_segment_tree/trait_extensions.mbt
+++ b/data_structures/immutable_segment_tree/trait_extensions.mbt
@@ -1,0 +1,17 @@
+///|
+pub extend Node with Debug::{to_repr}
+
+///|
+pub extend PersistentSegmentTreeError with Debug::{to_repr}
+
+///|
+pub extend PersistentSegmentTreeError with Eq::{not_equal, equal}
+
+///|
+pub extend PersistentSegmentTreeError with Show::{to_string, output}
+
+///|
+pub extend PersistentSegmentTree with Debug::{to_repr}
+
+///|
+pub extend PersistentSegmentTree with Show::{to_string, output}

--- a/data_structures/immutable_treap/immutable_treap.mbt
+++ b/data_structures/immutable_treap/immutable_treap.mbt
@@ -270,6 +270,6 @@ pub fn[K : Compare, V] PersistentTreap::remove(
 }
 
 ///|
-pub impl[K, V] Default for PersistentTreap[K, V] with default() {
+pub impl[K, V] Default for PersistentTreap[K, V] with fn default() {
   PersistentTreap::new()
 }

--- a/data_structures/immutable_treap/pkg.generated.mbti
+++ b/data_structures/immutable_treap/pkg.generated.mbti
@@ -15,6 +15,7 @@ pub struct PersistentTreap[K, V] {
 }
 pub fn[K, V] PersistentTreap::clear(Self[K, V]) -> Self[K, V]
 pub fn[K : Compare, V] PersistentTreap::contains(Self[K, V], K) -> Bool
+pub fn[K, V] PersistentTreap::default() -> Self[K, V]
 pub fn[K : Compare, V] PersistentTreap::get(Self[K, V], K) -> V?
 pub fn[K : Compare, V] PersistentTreap::insert(Self[K, V], K, V) -> Self[K, V]
 pub fn[K, V] PersistentTreap::is_empty(Self[K, V]) -> Bool
@@ -26,4 +27,3 @@ pub impl[K, V] Default for PersistentTreap[K, V]
 // Type aliases
 
 // Traits
-

--- a/data_structures/immutable_treap/trait_extensions.mbt
+++ b/data_structures/immutable_treap/trait_extensions.mbt
@@ -1,0 +1,2 @@
+///|
+pub extend PersistentTreap with Default::{default}

--- a/data_structures/immutable_trie/immutable_trie.mbt
+++ b/data_structures/immutable_trie/immutable_trie.mbt
@@ -155,6 +155,6 @@ pub fn[K, V : Eq] PersistentTrie::is_empty(self : PersistentTrie[K, V]) -> Bool 
 }
 
 ///|
-pub impl[K, V] Default for PersistentTrie[K, V] with default() {
+pub impl[K, V] Default for PersistentTrie[K, V] with fn default() {
   PersistentTrie::new()
 }

--- a/data_structures/immutable_trie/pkg.generated.mbti
+++ b/data_structures/immutable_trie/pkg.generated.mbti
@@ -11,6 +11,7 @@ pub struct PersistentTrie[K, V] {
 }
 pub fn[K, V] PersistentTrie::clear(Self[K, V]) -> Self[K, V]
 pub fn[K : Eq, V] PersistentTrie::contains(Self[K, V], Array[K]) -> Bool
+pub fn[K, V] PersistentTrie::default() -> Self[K, V]
 pub fn[K : Eq, V] PersistentTrie::get(Self[K, V], Array[K]) -> V?
 pub fn[K : Eq, V] PersistentTrie::insert(Self[K, V], Array[K], V) -> Self[K, V]
 pub fn[K, V : Eq] PersistentTrie::is_empty(Self[K, V]) -> Bool
@@ -22,4 +23,3 @@ type TrieNode[K, V]
 // Type aliases
 
 // Traits
-

--- a/data_structures/immutable_trie/trait_extensions.mbt
+++ b/data_structures/immutable_trie/trait_extensions.mbt
@@ -1,0 +1,2 @@
+///|
+pub extend PersistentTrie with Default::{default}

--- a/data_structures/kd_tree/pkg.generated.mbti
+++ b/data_structures/kd_tree/pkg.generated.mbti
@@ -23,4 +23,3 @@ type Node
 // Type aliases
 
 // Traits
-

--- a/data_structures/lazy_segment_tree/lazy_segment_tree.mbt
+++ b/data_structures/lazy_segment_tree/lazy_segment_tree.mbt
@@ -5,7 +5,7 @@ pub enum LazySegmentTreeError {
 } derive(Debug, Eq)
 
 ///|
-pub impl Show for LazySegmentTreeError with output(self, logger) {
+pub impl Show for LazySegmentTreeError with fn output(self, logger) {
   match self {
     IndexOutOfBounds => logger.write_string("IndexOutOfBounds")
     InvalidRange => logger.write_string("InvalidRange")

--- a/data_structures/lazy_segment_tree/pkg.generated.mbti
+++ b/data_structures/lazy_segment_tree/pkg.generated.mbti
@@ -22,14 +22,19 @@ pub struct LazySegmentTree[T, L] {
 pub fn[T : Default, L] LazySegmentTree::from_array(Array[T], (T, T) -> T, (T, L, Int) -> T, (L, L) -> L, L) -> Self[T, L]
 pub fn[T, L] LazySegmentTree::range_query(Self[T, L], Int, Int) -> Result[T?, LazySegmentTreeError]
 pub fn[T, L] LazySegmentTree::range_update(Self[T, L], Int, Int, L) -> Result[Unit, LazySegmentTreeError]
+pub fn[T : @debug.Debug, L : @debug.Debug] LazySegmentTree::to_repr(Self[T, L]) -> @debug.Repr
 
 pub enum LazySegmentTreeError {
   IndexOutOfBounds
   InvalidRange
 } derive(Eq, @debug.Debug)
+pub fn LazySegmentTreeError::equal(Self, Self) -> Bool
+pub fn LazySegmentTreeError::not_equal(Self, Self) -> Bool
+pub fn LazySegmentTreeError::output(Self, &Logger) -> Unit
+pub fn LazySegmentTreeError::to_repr(Self) -> @debug.Repr
+pub fn LazySegmentTreeError::to_string(Self) -> String
 pub impl Show for LazySegmentTreeError
 
 // Type aliases
 
 // Traits
-

--- a/data_structures/lazy_segment_tree/trait_extensions.mbt
+++ b/data_structures/lazy_segment_tree/trait_extensions.mbt
@@ -1,0 +1,11 @@
+///|
+pub extend LazySegmentTreeError with Debug::{to_repr}
+
+///|
+pub extend LazySegmentTreeError with Eq::{not_equal, equal}
+
+///|
+pub extend LazySegmentTreeError with Show::{to_string, output}
+
+///|
+pub extend LazySegmentTree with Debug::{to_repr}

--- a/data_structures/link_cut_tree/pkg.generated.mbti
+++ b/data_structures/link_cut_tree/pkg.generated.mbti
@@ -25,4 +25,3 @@ pub fn LinkCutTree::set_value(Self, Int, Int) -> Unit
 // Type aliases
 
 // Traits
-

--- a/data_structures/list/pkg.generated.mbti
+++ b/data_structures/list/pkg.generated.mbti
@@ -14,4 +14,3 @@ pub(all) enum List[T] {
 // Type aliases
 
 // Traits
-

--- a/data_structures/queue/pkg.generated.mbti
+++ b/data_structures/queue/pkg.generated.mbti
@@ -16,6 +16,7 @@ pub struct Queue[T] {
 }
 pub fn[T] Queue::back(Self[T]) -> @ref.Ref[T]?
 pub fn[T] Queue::clear(Self[T]) -> Unit
+pub fn[T : Default] Queue::default() -> Self[T]
 pub fn[T] Queue::front(Self[T]) -> @ref.Ref[T]?
 pub fn[T] Queue::is_empty(Self[T]) -> Bool
 pub fn[T] Queue::len(Self[T]) -> Int
@@ -27,4 +28,3 @@ pub impl[T : Default] Default for Queue[T]
 // Type aliases
 
 // Traits
-

--- a/data_structures/queue/queue.mbt
+++ b/data_structures/queue/queue.mbt
@@ -74,6 +74,6 @@ pub fn[T] Queue::clear(self : Queue[T]) -> Unit {
 // Implementing the Default trait for Queue
 
 ///|
-pub impl[T : Default] Default for Queue[T] with default() {
+pub impl[T : Default] Default for Queue[T] with fn default() {
   Queue::new()
 }

--- a/data_structures/queue/trait_extensions.mbt
+++ b/data_structures/queue/trait_extensions.mbt
@@ -1,0 +1,2 @@
+///|
+pub extend Queue with Default::{default}

--- a/data_structures/red_black_tree/pkg.generated.mbti
+++ b/data_structures/red_black_tree/pkg.generated.mbti
@@ -7,8 +7,12 @@ package "Lampese/Algorithms-Moonbit/data_structures/red_black_tree"
 
 // Types and methods
 type Color derive(Eq)
+pub fn Color::equal(Self, Self) -> Bool
+pub fn Color::not_equal(Self, Self) -> Bool
 
 type Node[K, V] derive(Eq)
+pub fn[K : Eq, V : Eq] Node::equal(Self[K, V], Self[K, V]) -> Bool
+pub fn[K : Eq, V : Eq] Node::not_equal(Self[K, V], Self[K, V]) -> Bool
 
 pub struct RedBlackTree[K, V] {
   mut root : Node[K, V]?
@@ -16,6 +20,7 @@ pub struct RedBlackTree[K, V] {
 }
 pub fn[K, V] RedBlackTree::clear(Self[K, V]) -> Unit
 pub fn[K : Compare, V] RedBlackTree::contains(Self[K, V], K) -> Bool
+pub fn[K, V] RedBlackTree::default() -> Self[K, V]
 pub fn[K : Compare, V] RedBlackTree::get(Self[K, V], K) -> V?
 pub fn[K : Compare, V] RedBlackTree::insert(Self[K, V], K, V) -> Unit
 pub fn[K, V] RedBlackTree::is_empty(Self[K, V]) -> Bool
@@ -27,4 +32,3 @@ pub impl[K, V] Default for RedBlackTree[K, V]
 // Type aliases
 
 // Traits
-

--- a/data_structures/red_black_tree/red_black_tree.mbt
+++ b/data_structures/red_black_tree/red_black_tree.mbt
@@ -383,6 +383,6 @@ pub fn[K : Compare, V : Eq] RedBlackTree::remove(
 }
 
 ///|
-pub impl[K, V] Default for RedBlackTree[K, V] with default() {
+pub impl[K, V] Default for RedBlackTree[K, V] with fn default() {
   RedBlackTree::new()
 }

--- a/data_structures/red_black_tree/trait_extensions.mbt
+++ b/data_structures/red_black_tree/trait_extensions.mbt
@@ -1,0 +1,8 @@
+///|
+pub extend Color with Eq::{not_equal, equal}
+
+///|
+pub extend Node with Eq::{not_equal, equal}
+
+///|
+pub extend RedBlackTree with Default::{default}

--- a/data_structures/scapegoat_tree/pkg.generated.mbti
+++ b/data_structures/scapegoat_tree/pkg.generated.mbti
@@ -15,6 +15,7 @@ pub struct ScapegoatTree[K, V] {
 }
 pub fn[K, V] ScapegoatTree::clear(Self[K, V]) -> Unit
 pub fn[K : Compare, V] ScapegoatTree::contains(Self[K, V], K) -> Bool
+pub fn[K, V] ScapegoatTree::default() -> Self[K, V]
 pub fn[K : Compare, V] ScapegoatTree::get(Self[K, V], K) -> V?
 pub fn[K : Compare, V] ScapegoatTree::insert(Self[K, V], K, V) -> Unit
 pub fn[K, V] ScapegoatTree::is_empty(Self[K, V]) -> Bool
@@ -26,4 +27,3 @@ pub impl[K, V] Default for ScapegoatTree[K, V]
 // Type aliases
 
 // Traits
-

--- a/data_structures/scapegoat_tree/scapegoat_tree.mbt
+++ b/data_structures/scapegoat_tree/scapegoat_tree.mbt
@@ -294,6 +294,6 @@ pub fn[K : Compare, V] ScapegoatTree::remove(
 }
 
 ///|
-pub impl[K, V] Default for ScapegoatTree[K, V] with default() {
+pub impl[K, V] Default for ScapegoatTree[K, V] with fn default() {
   ScapegoatTree::new()
 }

--- a/data_structures/scapegoat_tree/trait_extensions.mbt
+++ b/data_structures/scapegoat_tree/trait_extensions.mbt
@@ -1,0 +1,2 @@
+///|
+pub extend ScapegoatTree with Default::{default}

--- a/data_structures/segment_tree/pkg.generated.mbti
+++ b/data_structures/segment_tree/pkg.generated.mbti
@@ -17,15 +17,20 @@ pub struct SegmentTree[T] {
 } derive(@debug.Debug)
 pub fn[T : Default] SegmentTree::from_array(Array[T], (T, T) -> T) -> Self[T]
 pub fn[T] SegmentTree::query(Self[T], Int, Int) -> Result[T?, SegmentTreeError]
+pub fn[T : @debug.Debug] SegmentTree::to_repr(Self[T]) -> @debug.Repr
 pub fn[T : Eq] SegmentTree::update(Self[T], Int, T) -> Result[Unit, SegmentTreeError]
 
 pub enum SegmentTreeError {
   IndexOutOfBounds
   InvalidRange
 } derive(Eq, @debug.Debug)
+pub fn SegmentTreeError::equal(Self, Self) -> Bool
+pub fn SegmentTreeError::not_equal(Self, Self) -> Bool
+pub fn SegmentTreeError::output(Self, &Logger) -> Unit
+pub fn SegmentTreeError::to_repr(Self) -> @debug.Repr
+pub fn SegmentTreeError::to_string(Self) -> String
 pub impl Show for SegmentTreeError
 
 // Type aliases
 
 // Traits
-

--- a/data_structures/segment_tree/segment_tree.mbt
+++ b/data_structures/segment_tree/segment_tree.mbt
@@ -5,7 +5,7 @@ pub enum SegmentTreeError {
 } derive(Debug, Eq)
 
 ///|
-pub impl Show for SegmentTreeError with output(self, logger) {
+pub impl Show for SegmentTreeError with fn output(self, logger) {
   match self {
     IndexOutOfBounds => logger.write_string("IndexOutOfBounds")
     InvalidRange => logger.write_string("InvalidRange")

--- a/data_structures/segment_tree/trait_extensions.mbt
+++ b/data_structures/segment_tree/trait_extensions.mbt
@@ -1,0 +1,11 @@
+///|
+pub extend SegmentTreeError with Debug::{to_repr}
+
+///|
+pub extend SegmentTreeError with Eq::{not_equal, equal}
+
+///|
+pub extend SegmentTreeError with Show::{to_string, output}
+
+///|
+pub extend SegmentTree with Debug::{to_repr}

--- a/data_structures/splay/pkg.generated.mbti
+++ b/data_structures/splay/pkg.generated.mbti
@@ -14,6 +14,7 @@ pub struct SplayTree[K, V] {
 }
 pub fn[K, V] SplayTree::clear(Self[K, V]) -> Unit
 pub fn[K : Compare, V] SplayTree::contains(Self[K, V], K) -> Bool
+pub fn[K, V] SplayTree::default() -> Self[K, V]
 pub fn[K : Compare, V] SplayTree::get(Self[K, V], K) -> V?
 pub fn[K : Compare, V] SplayTree::insert(Self[K, V], K, V) -> Unit
 pub fn[K, V] SplayTree::is_empty(Self[K, V]) -> Bool
@@ -25,4 +26,3 @@ pub impl[K, V] Default for SplayTree[K, V]
 // Type aliases
 
 // Traits
-

--- a/data_structures/splay/splay.mbt
+++ b/data_structures/splay/splay.mbt
@@ -225,6 +225,6 @@ pub fn[K : Compare, V] SplayTree::remove(
 }
 
 ///|
-pub impl[K, V] Default for SplayTree[K, V] with default() {
+pub impl[K, V] Default for SplayTree[K, V] with fn default() {
   SplayTree::new()
 }

--- a/data_structures/splay/trait_extensions.mbt
+++ b/data_structures/splay/trait_extensions.mbt
@@ -1,0 +1,2 @@
+///|
+pub extend SplayTree with Default::{default}

--- a/data_structures/st/pkg.generated.mbti
+++ b/data_structures/st/pkg.generated.mbti
@@ -13,4 +13,3 @@ pub fn[T] ST::query(Self[T], Int, Int) -> T
 // Type aliases
 
 // Traits
-

--- a/data_structures/stack/pkg.generated.mbti
+++ b/data_structures/stack/pkg.generated.mbti
@@ -20,4 +20,3 @@ pub fn[T] Stack::to_array(Self[T]) -> Array[T]
 // Type aliases
 
 // Traits
-

--- a/data_structures/treap/pkg.generated.mbti
+++ b/data_structures/treap/pkg.generated.mbti
@@ -15,6 +15,7 @@ pub struct Treap[K, V] {
 }
 pub fn[K, V] Treap::clear(Self[K, V]) -> Unit
 pub fn[K : Compare, V] Treap::contains(Self[K, V], K) -> Bool
+pub fn[K, V] Treap::default() -> Self[K, V]
 pub fn[K : Compare, V] Treap::get(Self[K, V], K) -> V?
 pub fn[K : Compare, V] Treap::insert(Self[K, V], K, V) -> Unit
 pub fn[K, V] Treap::is_empty(Self[K, V]) -> Bool
@@ -26,4 +27,3 @@ pub impl[K, V] Default for Treap[K, V]
 // Type aliases
 
 // Traits
-

--- a/data_structures/treap/trait_extensions.mbt
+++ b/data_structures/treap/trait_extensions.mbt
@@ -1,0 +1,2 @@
+///|
+pub extend Treap with Default::{default}

--- a/data_structures/treap/treap.mbt
+++ b/data_structures/treap/treap.mbt
@@ -218,6 +218,6 @@ pub fn[K : Compare, V] Treap::remove(self : Treap[K, V], key : K) -> Bool {
 }
 
 ///|
-pub impl[K, V] Default for Treap[K, V] with default() {
+pub impl[K, V] Default for Treap[K, V] with fn default() {
   Treap::new()
 }

--- a/data_structures/trie/pkg.generated.mbti
+++ b/data_structures/trie/pkg.generated.mbti
@@ -11,6 +11,7 @@ pub struct Trie[K, V] {
 }
 pub fn[K, V] Trie::clear(Self[K, V]) -> Unit
 pub fn[K : Eq, V] Trie::contains(Self[K, V], Array[K]) -> Bool
+pub fn[K, V] Trie::default() -> Self[K, V]
 pub fn[K : Eq, V] Trie::get(Self[K, V], Array[K]) -> V?
 pub fn[K : Eq, V] Trie::insert(Self[K, V], Array[K], V) -> Unit
 pub fn[K, V : Eq] Trie::is_empty(Self[K, V]) -> Bool
@@ -22,4 +23,3 @@ type TrieNode[K, V]
 // Type aliases
 
 // Traits
-

--- a/data_structures/trie/trait_extensions.mbt
+++ b/data_structures/trie/trait_extensions.mbt
@@ -1,0 +1,2 @@
+///|
+pub extend Trie with Default::{default}

--- a/data_structures/trie/trie.mbt
+++ b/data_structures/trie/trie.mbt
@@ -136,6 +136,6 @@ pub fn[K, V : Eq] Trie::is_empty(self : Trie[K, V]) -> Bool {
 }
 
 ///|
-pub impl[K, V] Default for Trie[K, V] with default() {
+pub impl[K, V] Default for Trie[K, V] with fn default() {
   Trie::new()
 }

--- a/graph/apsp/pkg.generated.mbti
+++ b/graph/apsp/pkg.generated.mbti
@@ -13,4 +13,3 @@ pub fn Floyd::query(Self, Int, Int) -> Int
 // Type aliases
 
 // Traits
-

--- a/graph/lca/pkg.generated.mbti
+++ b/graph/lca/pkg.generated.mbti
@@ -14,4 +14,3 @@ pub fn LCA::lca(Self, Int, Int) -> Int
 // Type aliases
 
 // Traits
-

--- a/inverse_pair/pkg.generated.mbti
+++ b/inverse_pair/pkg.generated.mbti
@@ -11,4 +11,3 @@ pub fn[T : Compare] inverse_pair(Array[T]) -> Int
 // Type aliases
 
 // Traits
-

--- a/math/catalan/pkg.generated.mbti
+++ b/math/catalan/pkg.generated.mbti
@@ -15,4 +15,3 @@ pub fn Catalan::values(Self) -> Array[Int64]
 // Type aliases
 
 // Traits
-

--- a/math/combinator/pkg.generated.mbti
+++ b/math/combinator/pkg.generated.mbti
@@ -14,4 +14,3 @@ pub fn Comb::new(Int, Int64) -> Self
 // Type aliases
 
 // Traits
-

--- a/math/fft/pkg.generated.mbti
+++ b/math/fft/pkg.generated.mbti
@@ -14,4 +14,3 @@ type Complex
 // Type aliases
 
 // Traits
-

--- a/math/linear_basis/pkg.generated.mbti
+++ b/math/linear_basis/pkg.generated.mbti
@@ -19,4 +19,3 @@ pub fn LinearBasis::vectors(Self) -> Array[Int64]
 // Type aliases
 
 // Traits
-

--- a/moon.mod
+++ b/moon.mod
@@ -1,0 +1,13 @@
+name = "Lampese/Algorithms-Moonbit"
+
+version = "0.1.0"
+
+readme = "README.md"
+
+repository = "https://github.com/moonbit-community/Algorithms-Moonbit"
+
+license = "Apache-2.0"
+
+keywords = [ "algorithms", "data-structures" ]
+
+description = "Algorithms in moonbit."

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,9 +1,0 @@
-{
-  "name": "Lampese/Algorithms-Moonbit",
-  "version": "0.1.0",
-  "readme": "README.md",
-  "repository": "https://github.com/moonbit-community/Algorithms-Moonbit",
-  "license": "Apache-2.0",
-  "keywords": ["algorithms","data-structures"],
-  "description": "Algorithms in moonbit."
-}

--- a/prefix_sum/pkg.generated.mbti
+++ b/prefix_sum/pkg.generated.mbti
@@ -13,12 +13,13 @@ import {
 type Prefix1d[T] derive(@debug.Debug)
 pub fn[T : Add + Default] Prefix1d::from(Array[T]) -> Self[T]
 pub fn[T : Sub] Prefix1d::sum(Self[T], Int, Int) -> T
+pub fn[T : @debug.Debug] Prefix1d::to_repr(Self[T]) -> @debug.Repr
 
 type Prefix2d[T] derive(@debug.Debug)
 pub fn[T : Add + Sub + Default] Prefix2d::from(Array[Array[T]]) -> Self[T]
 pub fn[T : Add + Sub] Prefix2d::sum(Self[T], Int, Int, Int, Int) -> T
+pub fn[T : @debug.Debug] Prefix2d::to_repr(Self[T]) -> @debug.Repr
 
 // Type aliases
 
 // Traits
-

--- a/prefix_sum/prefix.mbt
+++ b/prefix_sum/prefix.mbt
@@ -15,7 +15,7 @@ enum Prefix2d[T] {
 ///|
 fn[T : Add + Default] prefix1d(data : Array[T]) -> Array[T] {
   let n = data.length()
-  let ret : Array[T] = Array::make(n + 1, T::default())
+  let ret : Array[T] = Array::make(n + 1, Default::default())
   if n > 0 {
     ret[1] = data[0]
     for i = 1; i < n; i = i + 1 {
@@ -35,7 +35,7 @@ fn[T : Add + Sub + Default] prefix2d(data : Array[Array[T]]) -> Array[Array[T]] 
   }
   let m = data[0].length()
   let ret : Array[Array[T]] = Array::makei(n + 1, fn(_row : Int) {
-    Array::make(m + 1, T::default())
+    Array::make(m + 1, Default::default())
   })
   for i = 1; i <= n; i = i + 1 {
     for j = 1; j <= m; j = j + 1 {

--- a/prefix_sum/trait_extensions.mbt
+++ b/prefix_sum/trait_extensions.mbt
@@ -1,0 +1,5 @@
+///|
+pub extend Prefix1d with Debug::{to_repr}
+
+///|
+pub extend Prefix2d with Debug::{to_repr}

--- a/string/SA/README.md
+++ b/string/SA/README.md
@@ -12,7 +12,7 @@ A mutable automaton storing states built from a source string. It can be extende
 ### SuffixAutomaton::new
 Creates an empty automaton. Accepts an optional alphabet size (default `512`, suitable for ASCII inputs).
 
-### SuffixAutomaton::extend
+### SuffixAutomaton::add_char
 Extends the automaton with a single character while maintaining suffix links and transitions.
 
 ### SuffixAutomaton::build

--- a/string/SA/pkg.generated.mbti
+++ b/string/SA/pkg.generated.mbti
@@ -13,11 +13,13 @@ pub struct SuffixAutomaton {
   alphabet_size : Int
   mut last : Int
 }
+#alias(extend, deprecated)
+pub fn SuffixAutomaton::add_char(Self, Char) -> Unit
 pub fn SuffixAutomaton::build(Self, String) -> Unit
 pub fn SuffixAutomaton::clear(Self) -> Unit
 pub fn SuffixAutomaton::contains(Self, String) -> Bool
+pub fn SuffixAutomaton::default() -> Self
 pub fn SuffixAutomaton::distinct_substring_count(Self) -> Int
-pub fn SuffixAutomaton::extend(Self, Char) -> Unit
 pub fn SuffixAutomaton::longest_common_substring_length(Self, String) -> Int
 pub fn SuffixAutomaton::new(alphabet_size? : Int) -> Self
 pub impl Default for SuffixAutomaton
@@ -25,4 +27,3 @@ pub impl Default for SuffixAutomaton
 // Type aliases
 
 // Traits
-

--- a/string/SA/suffix_automaton.mbt
+++ b/string/SA/suffix_automaton.mbt
@@ -40,7 +40,8 @@ pub fn SuffixAutomaton::clear(self : SuffixAutomaton) -> Unit {
 
 ///|
 /// Extend the automaton with a single character.
-pub fn SuffixAutomaton::extend(self : SuffixAutomaton, ch : Char) -> Unit {
+#alias(extend, deprecated)
+pub fn SuffixAutomaton::add_char(self : SuffixAutomaton, ch : Char) -> Unit {
   let c = ch.to_int()
   let cur_index = self.nodes.length()
   let cur_node = SANode::new(self.alphabet_size)
@@ -78,7 +79,7 @@ pub fn SuffixAutomaton::extend(self : SuffixAutomaton, ch : Char) -> Unit {
 pub fn SuffixAutomaton::build(self : SuffixAutomaton, s : String) -> Unit {
   self.clear()
   for i = 0; i < s.length(); i = i + 1 {
-    self.extend(s.code_unit_at(i).to_char().unwrap())
+    self.add_char(s.code_unit_at(i).to_char().unwrap())
   }
 }
 
@@ -146,6 +147,6 @@ pub fn SuffixAutomaton::longest_common_substring_length(
 }
 
 ///|
-pub impl Default for SuffixAutomaton with default() {
+pub impl Default for SuffixAutomaton with fn default() {
   SuffixAutomaton::new()
 }

--- a/string/SA/suffix_automaton_test.mbt
+++ b/string/SA/suffix_automaton_test.mbt
@@ -24,7 +24,7 @@ test "incremental extension matches build" {
   let sam_extend = SuffixAutomaton::new()
   let text = "banana"
   for i = 0; i < text.length(); i = i + 1 {
-    sam_extend.extend(text.code_unit_at(i).to_char().unwrap())
+    sam_extend.add_char(text.code_unit_at(i).to_char().unwrap())
   }
   assert_eq(true, sam_extend.contains("nan"))
   assert_eq(true, sam_extend.contains("banana"))

--- a/string/SA/trait_extensions.mbt
+++ b/string/SA/trait_extensions.mbt
@@ -1,0 +1,2 @@
+///|
+pub extend SuffixAutomaton with Default::{default}

--- a/string/aho_corasick/pkg.generated.mbti
+++ b/string/aho_corasick/pkg.generated.mbti
@@ -33,4 +33,3 @@ type ACNode
 // Type aliases
 
 // Traits
-

--- a/string/kmp/pkg.generated.mbti
+++ b/string/kmp/pkg.generated.mbti
@@ -13,4 +13,3 @@ pub fn z_func(String, t? : String) -> Array[Int]
 // Type aliases
 
 // Traits
-

--- a/string/manacher/pkg.generated.mbti
+++ b/string/manacher/pkg.generated.mbti
@@ -11,4 +11,3 @@ pub fn manacher(String) -> Int
 // Type aliases
 
 // Traits
-

--- a/string/string_hash/pkg.generated.mbti
+++ b/string/string_hash/pkg.generated.mbti
@@ -21,4 +21,3 @@ pub fn StringHash::new(mod? : Int64, base? : Int64, String) -> Self
 // Type aliases
 
 // Traits
-


### PR DESCRIPTION
## Summary

- Fix 37 frozen nightly warnings: `0079` (34), `0083` (2), and `0035` (1).
- Add explicit trait extensions to preserve the existing dot-method surface.
- Replace deprecated type-qualified defaults with `Default::default()`.
- Rename the public `SuffixAutomaton::extend` method to `add_char` while retaining a deprecated compatibility alias for `extend`.
- Apply current manifest and legacy impl-syntax migrations.

Validated with `moon 0.1.20260815` / nightly `moonc v0.10.8` and `MOON_IGNORE_PREBUILD=1 MOON_WORK=off`.

## Validation

- Four-target `moon check --target <target> --deny-warn` passed
- Four-target `moon test --target <target> --deny-warn` passed, 195/195 on each target
- `moon fmt`, `moon info`, and `git diff --check` passed

The public compatibility alias and generated interface were reviewed; no API removal is intended.